### PR TITLE
Fix readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # nodenv-aliases
 
-[![Latest GitHub Release](https://img.shields.io/github/v/release/nodenv/nodenv-aliases?logo=github&sort=semver)](https://github.com/nodenv/nodenv-aliases/releases/latest)
-[![Latest npm Release](https://img.shields.io/npm/v/@nodenv/nodenv-aliases)](https://www.npmjs.com/package/@nodenv/nodenv-aliases/v/latest)
-[![Test](https://img.shields.io/github/workflow/status/nodenv/nodenv-aliases/Test?label=tests&logo=github)](https://github.com/nodenv/nodenv-aliases/actions?query=workflow%3ATest)
-
 Aliases for nodenv Node versions
+
+[![Tests](https://img.shields.io/github/actions/workflow/status/nodenv/nodenv-aliases/test.yml?label=tests&logo=github)](https://github.com/nodenv/nodenv-aliases/actions/workflows/test.yml)
+[![Latest GitHub Release](https://img.shields.io/github/v/release/nodenv/nodenv-aliases?label=github&logo=github&sort=semver)](https://github.com/nodenv/nodenv-aliases/releases/latest)
+[![Latest Homebrew Release](<https://img.shields.io/badge/dynamic/regex?label=homebrew-nodenv&logo=homebrew&logoColor=white&url=https%3A%2F%2Fraw.githubusercontent.com%2Fnodenv%2Fhomebrew-nodenv%2Frefs%2Fheads%2Fmain%2FFormula%2Fnodenv-aliases.rb&search=archive%2Frefs%2Ftags%2Fv(%3F%3Cversion%3E%5Cd%2B.*).tar.gz&replace=v%24%3Cversion%3E>)](https://github.com/nodenv/homebrew-nodenv/blob/main/Formula/nodenv-aliases.rb)
+[![Latest npm Release](https://img.shields.io/npm/v/@nodenv/nodenv-aliases?logo=npm&logoColor=white)](https://www.npmjs.com/package/@nodenv/nodenv-aliases/v/latest)
 
 Invoke `nodenv alias <name> <version>` to make a symbolic link from `<name>` to
 `<version>` in the [nodenv][] versions directory, effectively creating an

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": "bats ${CI:+--tap} test",
     "posttest": "npm run lint",
     "lint": "git ls-files bin etc script */*.*sh | xargs shellcheck",
-    "lint:format": "prettier --write .",
+    "lint:fix": "prettier --write .",
+    "postlint": "prettier --check .",
     "postversion": "git push --follow-tags"
   },
   "dependencies": {


### PR DESCRIPTION
github, homebrew, npm (alphabetical ordering)

use blue for homebrew to match the other release badges, even though it defaults to orange.

update the GHA badge to use proper format.